### PR TITLE
Compatibility with PHP 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,21 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
+        "php": ">=5.6.4",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^6.2",
+        "symfony/polyfill-php70": "^1.13",
+        "symfony/polyfill-php71": "^1.13",
+        "symfony/polyfill-php72": "^1.13"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "~2.6",
-        "friendsofphp/php-cs-fixer": "~2.12"
+        "friendsofphp/php-cs-fixer": "~2.12",
+        "phpcompatibility/php-compatibility": "*",
+        "phpcompatibility/phpcompatibility-wp": "*",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.5.0"
     },
     "autoload": {
         "psr-4": { "MuxPhp\\" : "MuxPhp/" }


### PR DESCRIPTION
We have the misfortune of having to support a few customers who still use 5.6.  We will stop supporting it in the very near future, but until then ...

Your library is compatible with 5.6 though.  I've added the polyfills just in case, but guzzle already includes most of them as well.