### PR TITLE
Add audio.m4a to allowed static asset names

### DIFF
--- a/MuxPhp/Models/AssetStaticRenditionsFiles.php
+++ b/MuxPhp/Models/AssetStaticRenditionsFiles.php
@@ -162,10 +162,12 @@ class AssetStaticRenditionsFiles implements ModelInterface, ArrayAccess
     const NAME_LOWMP4 = 'low.mp4';
     const NAME_MEDIUMMP4 = 'medium.mp4';
     const NAME_HIGHMP4 = 'high.mp4';
+    const NAME_AUDIOM4A='audio.m4a';
     const EXT_MP4 = 'mp4';
-    
+    const EXT_M4A = 'm4a';
 
-    
+
+
     /**
      * Gets allowable values of the enum
      *
@@ -177,9 +179,10 @@ class AssetStaticRenditionsFiles implements ModelInterface, ArrayAccess
             self::NAME_LOWMP4,
             self::NAME_MEDIUMMP4,
             self::NAME_HIGHMP4,
+            self::NAME_AUDIOM4A,
         ];
     }
-    
+
     /**
      * Gets allowable values of the enum
      *
@@ -189,9 +192,10 @@ class AssetStaticRenditionsFiles implements ModelInterface, ArrayAccess
     {
         return [
             self::EXT_MP4,
+            self::EXT_M4A
         ];
     }
-    
+
 
     /**
      * Associative array for storing property values
@@ -483,5 +487,3 @@ class AssetStaticRenditionsFiles implements ModelInterface, ArrayAccess
         );
     }
 }
-
-


### PR DESCRIPTION
I noticed calling getAsset() on a audio-only asset with mp4support on caused an error as the audio.m4a filename isn't recognised.  

I suspect this is better changed higher up the chain and this library regenerated.  