### PR TITLE
PHP compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2.5",
+        "php": ">=8.1",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",


### PR DESCRIPTION
Since release 3.4.0 the package is no longer support by PHP versions below 8.1. The release notes say that support below 7.4 is dropped. But the change for example in https://github.com/muxinc/mux-php/blob/40178372ad8d3b3f60ec60fddb02e193ea711168/MuxPhp/Models/PlaybackID.php#L287  adding type declaration "mixed" (https://www.php.net/manual/en/language.types.declarations.php) is only supported since PHP 8, and breaks implementations below that. 

It broke our implementation while updated by our dependency bot.

`TypeError: Return value of MuxPhp\Models\PlaybackID::offsetGet() must be an instance of MuxPhp\Models\mixed, string returned in file /vendor/muxinc/mux-php/MuxPhp/Models/PlaybackID.php on line 289
`

Not sure if support for 7.4 should be dropped, since this requires all users to update to PHP 8.1.