### PR TITLE
Update docs to fix example

### DIFF
--- a/docs/Api/AssetsApi.md
+++ b/docs/Api/AssetsApi.md
@@ -682,7 +682,7 @@ $apiInstance = new MuxPhp\Api\AssetsApi(
     $config
 );
 $asset_id = 'asset_id_example'; // string | The asset ID.
-$update_asset_request = {"passthrough":"Example"}; // \MuxPhp\Models\UpdateAssetRequest
+$update_asset_request = new \MuxPhp\Models\UpdateAssetRequest(['passthrough' => "Example"]); // \MuxPhp\Models\UpdateAssetRequest
 
 try {
     $result = $apiInstance->updateAsset($asset_id, $update_asset_request);


### PR DESCRIPTION
Currently, the example used in the docs is not working if users will copy and paste them.

The `updateAsset` function requires an array to be set, 'json' is not a valid input.

TypeError: Argument 1 passed to MuxPhp\Models\UpdateAssetRequest::__construct() must be of the type array or null, string given, called in /filename.php on line 74 in file /vendor/muxinc/mux-php/MuxPhp/Models/UpdateAssetRequest.php on line 183.