### PR TITLE
Improve documentation of using epoch timestamps for Data timeframe

### DIFF
--- a/docs/Api/MetricsApi.md
+++ b/docs/Api/MetricsApi.md
@@ -113,7 +113,7 @@ $apiInstance = new MuxPhp\Api\MetricsApi(
     $config
 );
 $metric_id = video_startup_time; // string | ID of the Metric
-$timeframe = array('timeframe_example'); // string[] | Timeframe window to limit results by. Must be provided as an array query string parameter (e.g. timeframe[]=).  Accepted formats are...    * array of epoch timestamps e.g. `timeframe[]=1498867200&timeframe[]=1498953600`   * duration string e.g. `timeframe[]=24:hours or timeframe[]=7:days`
+$timeframe = array('timeframe' => [1498867200, 1498953600]); // string[] | Timeframe window to limit results by. Must be provided as an array query string parameter (e.g. timeframe[]=).  Accepted formats are...    * array of epoch timestamps e.g. `timeframe[]=1498867200&timeframe[]=1498953600`   * duration string e.g. `timeframe[]=24:hours or timeframe[]=7:days`
 $filters = array('filters_example'); // string[] | Limit the results to rows that match conditions from provided key:value pairs. Must be provided as an array query string parameter.  To exclude rows that match a certain condition, prepend a `!` character to the dimension.  Possible filter names are the same as returned by the List Filters endpoint.  Example:    * `filters[]=operating_system:windows&filters[]=!country:US`
 $measurement = 'measurement_example'; // string | Measurement for the provided metric. If omitted, the default for the metric will be used.
 

--- a/examples/data/exercise-metrics.php
+++ b/examples/data/exercise-metrics.php
@@ -21,7 +21,7 @@
     print("list-breakdown-values OK ✅\n");
 
     // ========== get-overall-values ==========
-    $overall = $metricsApi->getOverallValues("video_startup_time", ["timeframe" => ["7:days"]]);
+    $overall = $metricsApi->getOverallValues("video_startup_time", ["timeframe" => [1498867200, 1498953600]]);
     assert($overall->getData() !== null);
     print("get-overall-values OK ✅\n");
 

--- a/examples/data/exercise-metrics.php
+++ b/examples/data/exercise-metrics.php
@@ -22,6 +22,7 @@
 
     // ========== get-overall-values ==========
     $overall = $metricsApi->getOverallValues("video_startup_time", ["timeframe" => ["7:days"]]);
+    // Alternatively specify an array of epoch timestamps e.g.: $overall = $metricsApi->getOverallValues("video_startup_time", ["timeframe" => [1498867200, 1498953600]]);
     assert($overall->getData() !== null);
     print("get-overall-values OK ✅\n");
 

--- a/examples/data/exercise-metrics.php
+++ b/examples/data/exercise-metrics.php
@@ -21,7 +21,7 @@
     print("list-breakdown-values OK ✅\n");
 
     // ========== get-overall-values ==========
-    $overall = $metricsApi->getOverallValues("video_startup_time", ["timeframe" => [1498867200, 1498953600]]);
+    $overall = $metricsApi->getOverallValues("video_startup_time", ["timeframe" => ["7:days"]]);
     assert($overall->getData() !== null);
     print("get-overall-values OK ✅\n");
 


### PR DESCRIPTION
I has trouble understanding how to pass timestamps for a timeframe. Since there were no examples or specific documentation of using the library to do so, I ended up diving the source to understand how `ObjectSerializer::buildBetterQuery` works. I think it would help other developers to have at least one example that uses timestamps.

## Before
![CleanShot 2023-09-12 at 16 53 14@2x](https://github.com/muxinc/mux-php/assets/1800175/eb33fcdc-6fbc-4882-8a86-eab0b455d85c)

## After
![CleanShot 2023-09-12 at 16 52 40@2x](https://github.com/muxinc/mux-php/assets/1800175/5e217e5c-45bf-44ed-adb2-21b6651917ef)
