### PR TITLE
Fix comment typos in data exercises

### DIFF
--- a/examples/data/exercise-incidents.php
+++ b/examples/data/exercise-incidents.php
@@ -13,7 +13,7 @@
         $config
     );
 
-    // Test coverage here is poor due to not knowning if the account we're testing against has any incidents.
+    // Test coverage here is poor due to not knowing if the account we're testing against has any incidents.
 
     // ========== list-incidents ==========
     $incidents = $incidentsApi->listIncidents();

--- a/examples/data/exercise-monitoring.php
+++ b/examples/data/exercise-monitoring.php
@@ -13,8 +13,8 @@
         $config
     );
 
-    // Test coverage here isn't fantastic due to not knowning if the account we're testing against has
-    // any monitring data. The behaviour has been manually verified against real-world data.
+    // Test coverage here isn't fantastic due to not knowing if the account we're testing against has
+    // any monitoring data. The behaviour has been manually verified against real-world data.
 
     // ========== list-monitoring-dimensions ==========
     $dimensions = $monitoringApi->listMonitoringDimensions();


### PR DESCRIPTION
This PR fixes a couple small typos I came across in the examples.