### PR TITLE
fix: Call to undefined function GuzzleHttp\\Psr7\\build_query() #57

### DIFF
--- a/MuxPhp/Api/AssetsApi.php
+++ b/MuxPhp/Api/AssetsApi.php
@@ -355,7 +355,7 @@ class AssetsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -646,7 +646,7 @@ class AssetsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -937,7 +937,7 @@ class AssetsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1163,7 +1163,7 @@ class AssetsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1408,7 +1408,7 @@ class AssetsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1653,7 +1653,7 @@ class AssetsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1927,7 +1927,7 @@ class AssetsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -2201,7 +2201,7 @@ class AssetsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -2494,7 +2494,7 @@ class AssetsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -2813,7 +2813,7 @@ class AssetsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -3104,7 +3104,7 @@ class AssetsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -3395,7 +3395,7 @@ class AssetsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -3686,7 +3686,7 @@ class AssetsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 

--- a/MuxPhp/Api/DeliveryUsageApi.php
+++ b/MuxPhp/Api/DeliveryUsageApi.php
@@ -418,7 +418,7 @@ class DeliveryUsageApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 

--- a/MuxPhp/Api/DimensionsApi.php
+++ b/MuxPhp/Api/DimensionsApi.php
@@ -421,7 +421,7 @@ class DimensionsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -676,7 +676,7 @@ class DimensionsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 

--- a/MuxPhp/Api/DirectUploadsApi.php
+++ b/MuxPhp/Api/DirectUploadsApi.php
@@ -357,7 +357,7 @@ class DirectUploadsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -629,7 +629,7 @@ class DirectUploadsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -903,7 +903,7 @@ class DirectUploadsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1190,7 +1190,7 @@ class DirectUploadsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 

--- a/MuxPhp/Api/ErrorsApi.php
+++ b/MuxPhp/Api/ErrorsApi.php
@@ -370,7 +370,7 @@ class ErrorsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 

--- a/MuxPhp/Api/ExportsApi.php
+++ b/MuxPhp/Api/ExportsApi.php
@@ -338,7 +338,7 @@ class ExportsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -593,7 +593,7 @@ class ExportsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 

--- a/MuxPhp/Api/FiltersApi.php
+++ b/MuxPhp/Api/FiltersApi.php
@@ -421,7 +421,7 @@ class FiltersApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -676,7 +676,7 @@ class FiltersApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 

--- a/MuxPhp/Api/IncidentsApi.php
+++ b/MuxPhp/Api/IncidentsApi.php
@@ -357,7 +357,7 @@ class IncidentsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -708,7 +708,7 @@ class IncidentsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1046,7 +1046,7 @@ class IncidentsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 

--- a/MuxPhp/Api/LiveStreamsApi.php
+++ b/MuxPhp/Api/LiveStreamsApi.php
@@ -355,7 +355,7 @@ class LiveStreamsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -646,7 +646,7 @@ class LiveStreamsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -937,7 +937,7 @@ class LiveStreamsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1163,7 +1163,7 @@ class LiveStreamsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1408,7 +1408,7 @@ class LiveStreamsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1653,7 +1653,7 @@ class LiveStreamsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1927,7 +1927,7 @@ class LiveStreamsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -2201,7 +2201,7 @@ class LiveStreamsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -2475,7 +2475,7 @@ class LiveStreamsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -2768,7 +2768,7 @@ class LiveStreamsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -3061,7 +3061,7 @@ class LiveStreamsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -3380,7 +3380,7 @@ class LiveStreamsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -3654,7 +3654,7 @@ class LiveStreamsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -3928,7 +3928,7 @@ class LiveStreamsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -4219,7 +4219,7 @@ class LiveStreamsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -4510,7 +4510,7 @@ class LiveStreamsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -4801,7 +4801,7 @@ class LiveStreamsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 

--- a/MuxPhp/Api/MetricsApi.php
+++ b/MuxPhp/Api/MetricsApi.php
@@ -437,7 +437,7 @@ class MetricsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -759,7 +759,7 @@ class MetricsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1078,7 +1078,7 @@ class MetricsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1480,7 +1480,7 @@ class MetricsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1802,7 +1802,7 @@ class MetricsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 

--- a/MuxPhp/Api/MonitoringApi.php
+++ b/MuxPhp/Api/MonitoringApi.php
@@ -437,7 +437,7 @@ class MonitoringApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -807,7 +807,7 @@ class MonitoringApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1097,7 +1097,7 @@ class MonitoringApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1403,7 +1403,7 @@ class MonitoringApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1658,7 +1658,7 @@ class MonitoringApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1913,7 +1913,7 @@ class MonitoringApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 

--- a/MuxPhp/Api/PlaybackIDApi.php
+++ b/MuxPhp/Api/PlaybackIDApi.php
@@ -357,7 +357,7 @@ class PlaybackIDApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 

--- a/MuxPhp/Api/PlaybackRestrictionsApi.php
+++ b/MuxPhp/Api/PlaybackRestrictionsApi.php
@@ -355,7 +355,7 @@ class PlaybackRestrictionsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -581,7 +581,7 @@ class PlaybackRestrictionsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -855,7 +855,7 @@ class PlaybackRestrictionsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1142,7 +1142,7 @@ class PlaybackRestrictionsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1433,7 +1433,7 @@ class PlaybackRestrictionsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 

--- a/MuxPhp/Api/RealTimeApi.php
+++ b/MuxPhp/Api/RealTimeApi.php
@@ -437,7 +437,7 @@ class RealTimeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -727,7 +727,7 @@ class RealTimeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1033,7 +1033,7 @@ class RealTimeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1288,7 +1288,7 @@ class RealTimeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1543,7 +1543,7 @@ class RealTimeApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 

--- a/MuxPhp/Api/SigningKeysApi.php
+++ b/MuxPhp/Api/SigningKeysApi.php
@@ -338,7 +338,7 @@ class SigningKeysApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -564,7 +564,7 @@ class SigningKeysApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -838,7 +838,7 @@ class SigningKeysApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1125,7 +1125,7 @@ class SigningKeysApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 

--- a/MuxPhp/Api/SpacesApi.php
+++ b/MuxPhp/Api/SpacesApi.php
@@ -355,7 +355,7 @@ class SpacesApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -646,7 +646,7 @@ class SpacesApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -872,7 +872,7 @@ class SpacesApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1117,7 +1117,7 @@ class SpacesApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1391,7 +1391,7 @@ class SpacesApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1684,7 +1684,7 @@ class SpacesApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1971,7 +1971,7 @@ class SpacesApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -2264,7 +2264,7 @@ class SpacesApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -2557,7 +2557,7 @@ class SpacesApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 

--- a/MuxPhp/Api/TranscriptionVocabulariesApi.php
+++ b/MuxPhp/Api/TranscriptionVocabulariesApi.php
@@ -355,7 +355,7 @@ class TranscriptionVocabulariesApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -581,7 +581,7 @@ class TranscriptionVocabulariesApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -855,7 +855,7 @@ class TranscriptionVocabulariesApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1146,7 +1146,7 @@ class TranscriptionVocabulariesApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1437,7 +1437,7 @@ class TranscriptionVocabulariesApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 

--- a/MuxPhp/Api/URLSigningKeysApi.php
+++ b/MuxPhp/Api/URLSigningKeysApi.php
@@ -338,7 +338,7 @@ class URLSigningKeysApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -564,7 +564,7 @@ class URLSigningKeysApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -838,7 +838,7 @@ class URLSigningKeysApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1125,7 +1125,7 @@ class URLSigningKeysApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 

--- a/MuxPhp/Api/VideoViewsApi.php
+++ b/MuxPhp/Api/VideoViewsApi.php
@@ -357,7 +357,7 @@ class VideoViewsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -724,7 +724,7 @@ class VideoViewsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 

--- a/MuxPhp/Api/WebInputsApi.php
+++ b/MuxPhp/Api/WebInputsApi.php
@@ -355,7 +355,7 @@ class WebInputsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -581,7 +581,7 @@ class WebInputsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -855,7 +855,7 @@ class WebInputsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1129,7 +1129,7 @@ class WebInputsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1416,7 +1416,7 @@ class WebInputsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1690,7 +1690,7 @@ class WebInputsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -1964,7 +1964,7 @@ class WebInputsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 
@@ -2255,7 +2255,7 @@ class WebInputsApi
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 

--- a/gen/templates/api.mustache
+++ b/gen/templates/api.mustache
@@ -591,7 +591,7 @@ use {{invokerPackage}}\ObjectSerializer;
 
             } else {
                 // for HTTP post (form)
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = \GuzzleHttp\Psr7\query($formParams);
             }
         }
 


### PR DESCRIPTION
### Description:

With recent updates to the GuzzleHttp library, the `build_query()` function has been deprecated, causing runtime errors in the codebase. This pull request addresses these issues by replacing the deprecated function with the alternative `build()`, ensuring seamless integration with the latest GuzzleHttp changes.

### Changes Made:

- Updated the usage of the deprecated `build_query()` function to resolve "Call to undefined function" errors.
- Introduced the new function `build()` as a replacement.

### Context:

The deprecation of `build_query()` necessitated this update to prevent runtime errors. The introduction of `build()` serves as the appropriate alternative, ensuring compatibility and smooth integration with the latest GuzzleHttp changes.

### Related Issue:

Closes #57