### PR TITLE
Simplify install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,25 +27,31 @@ Dependencies are managed using composer.
 
 ## Installation
 
-We publish Mux PHP to [Packagist](https://packagist.org/packages/muxinc/mux-php). You should depend on Mux PHP by adding us to your composer.json:
+We publish Mux PHP to [Packagist](https://packagist.org/packages/muxinc/mux-php). Run `composer require` to get the latest version:
+
+```shell
+composer require muxinc/mux-php
+```
+
+You can also add Mux PHP directly to your composer.json:
 
 ```json
-    {
-        "require": {
-            "muxinc/mux-php": ">=0.0.1"
-        }
+{
+    "require": {
+        "muxinc/mux-php": ">=0.0.1"
     }
+}
 ```
 Then install your dependencies:
 
 ```sh
-    composer install
+composer install
 ```
 
 And then autoload in your code:
 
 ```php
-    require_once 'vendor/autoload.php';
+require_once 'vendor/autoload.php';
 ```
 
 ### Manual Installation
@@ -84,26 +90,26 @@ Please note that our SDK and the API documentation are generated from our OpenAP
 Below is a quick example of using mux-php to ingest a new Video in your Mux account.
 
 ```php
-    // Authentication Setup
-    $config = MuxPhp\Configuration::getDefaultConfiguration()
-        ->setUsername(getenv('MUX_TOKEN_ID'))
-        ->setPassword(getenv('MUX_TOKEN_SECRET'));
+// Authentication Setup
+$config = MuxPhp\Configuration::getDefaultConfiguration()
+    ->setUsername(getenv('MUX_TOKEN_ID'))
+    ->setPassword(getenv('MUX_TOKEN_SECRET'));
 
-    // API Client Initialization
-    $assetsApi = new MuxPhp\Api\AssetsApi(
-        new GuzzleHttp\Client(),
-        $config
-    );
+// API Client Initialization
+$assetsApi = new MuxPhp\Api\AssetsApi(
+    new GuzzleHttp\Client(),
+    $config
+);
 
-    // Create Asset Request
-    $input = new MuxPhp\Models\InputSettings(["url" => "https://storage.googleapis.com/muxdemofiles/mux-video-intro.mp4"]);
-    $createAssetRequest = new MuxPhp\Models\CreateAssetRequest(["input" => $input, "playback_policy" => [MuxPhp\Models\PlaybackPolicy::_PUBLIC] ]);
+// Create Asset Request
+$input = new MuxPhp\Models\InputSettings(["url" => "https://storage.googleapis.com/muxdemofiles/mux-video-intro.mp4"]);
+$createAssetRequest = new MuxPhp\Models\CreateAssetRequest(["input" => $input, "playback_policy" => [MuxPhp\Models\PlaybackPolicy::_PUBLIC] ]);
 
-    // Ingest
-    $result = $assetsApi->createAsset($createAssetRequest);
+// Ingest
+$result = $assetsApi->createAsset($createAssetRequest);
 
-    // Print URL
-    print "Playback URL: https://stream.mux.com/" . $result->getData()->getPlaybackIds()[0]->getId() . ".m3u8\n";
+// Print URL
+print "Playback URL: https://stream.mux.com/" . $result->getData()->getPlaybackIds()[0]->getId() . ".m3u8\n";
 ```
 
 Be sure to also checkout the [examples directory](examples/):


### PR DESCRIPTION
Adds the one-line `composer require` install option as the primary method, with the older one as a backup